### PR TITLE
Define BuiltIn BagProfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ referenced in order to be loaded.
 *e.g. Using a Built In Profile*
 ```java
 final String profileIdentifier = "beyondtherepository";
-final BagProfile.BuildIn builtInProfile = BagProfile.BuiltIn.from(profileIdentifier);
-final BagProfile profile = new BagProfile(buildInProfile);
+final BagProfile.BuiltIn builtInProfile = BagProfile.BuiltIn.from(profileIdentifier);
+final BagProfile profile = new BagProfile(builtInProfile);
 ```
 
 ### Loading A Custom Bag Profile
@@ -217,4 +217,3 @@ final BagSerializer deserializer = SerializationSupport.deserializerFor(bag, pro
 
 final Path deserialized = deserializer.deserialize(bag);
 ```
-

--- a/README.md
+++ b/README.md
@@ -60,11 +60,9 @@ referenced in order to be loaded.
 
 *e.g. Using a Built In Profile*
 ```java
-final BagProfile profile;
-final URL json = this.getClass().getClassLoader().getResource("profiles/default.json");
-try (InputStream is = json.openStream()) {
-    profile = new BagProfile(is);
-}
+final String profileIdentifier = "beyondtherepository";
+final BagProfile.BuildIn builtInProfile = BagProfile.BuiltIn.from(profileIdentifier);
+final BagProfile profile = new BagProfile(buildInProfile);
 ```
 
 ### Loading A Custom Bag Profile

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -166,10 +166,12 @@ public class BagProfileTest {
         final Path profiles = Paths.get("src/main/resources/profiles");
 
         Files.list(profiles).forEach(path -> {
-            logger.debug("Validating {}", path);
+            String profileIdentifier = path.getFileName().toString();
+            profileIdentifier = profileIdentifier.substring(0, profileIdentifier.indexOf("."));
+            logger.debug("Validating {}", profileIdentifier);
             BagProfile profile = null;
             try {
-                profile = new BagProfile(Files.newInputStream(path));
+                profile = new BagProfile(BagProfile.BuiltIn.from(profileIdentifier));
             } catch (IOException e) {
                 Assert.fail(e.getMessage());
             }
@@ -352,8 +354,7 @@ public class BagProfileTest {
         bag.setItemsToFetch(Collections.singletonList(new FetchItem(fetchUrl, fetchLength, fetchFile)));
         bag.setVersion(new Version(0, 0));
         bag.setRootDir(Paths.get(targetDir, defaultBag));
-        final File testFile = new File("src/main/resources/profiles/aptrust.json");
-        final BagProfile bagProfile = new BagProfile(new FileInputStream(testFile));
+        final BagProfile bagProfile = new BagProfile(BagProfile.BuiltIn.APTRUST);
 
         putRequiredBagInfo(bag, bagProfile);
         putRequiredManifests(bag.getPayLoadManifests(), bagProfile.getPayloadDigestAlgorithms());


### PR DESCRIPTION
Adds an enum `BagProfile.BuiltIn` to represent the profiles which are included with bagit-support along with a default constructor for said profiles.