### PR TITLE
Set big number and long file mode for tar archives

### DIFF
--- a/src/main/java/org/duraspace/bagit/TarBagSerializer.java
+++ b/src/main/java/org/duraspace/bagit/TarBagSerializer.java
@@ -33,6 +33,8 @@ public class TarBagSerializer implements BagSerializer {
         final Path serializedBag = parent.resolve(bagName + extension);
         try(final OutputStream os = Files.newOutputStream(serializedBag);
             final TarArchiveOutputStream tar = new TarArchiveOutputStream(os)) {
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
             final List<Path> files = Files.walk(root).collect(Collectors.toList());
             for (Path bagEntry : files) {
                 final String name = parent.relativize(bagEntry).toString();

--- a/src/main/java/org/duraspace/bagit/TarGzBagSerializer.java
+++ b/src/main/java/org/duraspace/bagit/TarGzBagSerializer.java
@@ -35,6 +35,8 @@ public class TarGzBagSerializer implements BagSerializer {
         try(final OutputStream os = Files.newOutputStream(serializedBag);
             final GZIPOutputStream gzip = new GZIPOutputStream(os);
             final TarArchiveOutputStream tar = new TarArchiveOutputStream(gzip)) {
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
             final List<Path> files = Files.walk(root).collect(Collectors.toList());
             for (Path bagEntry : files) {
                 final String name = parent.relativize(bagEntry).toString();


### PR DESCRIPTION
Resolves #3 

Sets the LongFileMode and BigNumberMode to POSIX, which should offer the most compatibility with other implementations.