### PR TITLE
Fix description setting from json

### DIFF
--- a/src/main/java/org/duraspace/bagit/BagProfile.java
+++ b/src/main/java/org/duraspace/bagit/BagProfile.java
@@ -279,7 +279,7 @@ public class BagProfile {
             }
 
             final JsonNode descriptionNode = field.get("description");
-            if (descriptionNode != null && descriptionNode.asText().isEmpty()) {
+            if (descriptionNode != null && !descriptionNode.asText().isEmpty()) {
                 description = descriptionNode.asText();
             }
 

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -105,6 +105,8 @@ public class BagProfileTest {
         assertTrue(profile.getTagDigestAlgorithms().contains(sha512));
 
         assertTrue(profile.getMetadataFields().get(SOURCE_ORGANIZATION_KEY).isRequired());
+        assertEquals(profile.getMetadataFields().get(SOURCE_ORGANIZATION_KEY).getDescription(),
+                     SOURCE_ORGANIZATION_KEY);
         assertTrue(profile.getMetadataFields().get(ORGANIZATION_ADDRESS_KEY).isRequired());
         assertTrue(profile.getMetadataFields().get(CONTACT_NAME_KEY).isRequired());
         assertTrue(profile.getMetadataFields().get(CONTACT_PHONE_KEY).isRequired());
@@ -139,7 +141,6 @@ public class BagProfileTest {
         assertTrue(profile.getMetadataFields(aptrustInfo).get(ACCESS_KEY).getValues().contains("Consortia"));
         assertTrue(profile.getMetadataFields(aptrustInfo).get(ACCESS_KEY).getValues().contains("Institution"));
         assertTrue(profile.getMetadataFields(aptrustInfo).get(ACCESS_KEY).getValues().contains("Restricted"));
-
     }
 
 

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -87,6 +87,19 @@ public class BagProfileTest {
     }
 
     @Test
+    public void testBuiltInProfiles() {
+        // validate that the string passed in the constructor matches the string used in the switch statement
+        for (BagProfile.BuiltIn value : BagProfile.BuiltIn.values()) {
+            assertEquals(value, BagProfile.BuiltIn.from(value.getIdentifier()));
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuiltInNotSupported() {
+        BagProfile.BuiltIn.from("test");
+    }
+
+    @Test
     public void testBasicProfileFromFile() throws Exception {
         final BagProfile profile = new BagProfile(Files.newInputStream(resolveResourcePath(defaultProfilePath)));
 

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -105,9 +105,11 @@ public class BagProfileTest {
         assertTrue(profile.getTagDigestAlgorithms().contains(sha512));
 
         assertTrue(profile.getMetadataFields().get(SOURCE_ORGANIZATION_KEY).isRequired());
+        assertFalse(profile.getMetadataFields().get(SOURCE_ORGANIZATION_KEY).isRepeatable());
         assertEquals(profile.getMetadataFields().get(SOURCE_ORGANIZATION_KEY).getDescription(),
                      SOURCE_ORGANIZATION_KEY);
         assertTrue(profile.getMetadataFields().get(ORGANIZATION_ADDRESS_KEY).isRequired());
+        assertTrue(profile.getMetadataFields().get(ORGANIZATION_ADDRESS_KEY).isRepeatable());
         assertTrue(profile.getMetadataFields().get(CONTACT_NAME_KEY).isRequired());
         assertTrue(profile.getMetadataFields().get(CONTACT_PHONE_KEY).isRequired());
         assertTrue(profile.getMetadataFields().get(BAG_SIZE_KEY).isRequired());

--- a/src/test/resources/profiles/profile.json
+++ b/src/test/resources/profiles/profile.json
@@ -10,10 +10,13 @@
    },
    "Bag-Info":{
       "Source-Organization":{
-         "required":true
+         "required":true,
+         "repeatable": false,
+         "description": "Source-Organization"
       },
       "Organization-Address":{
-         "required":true
+         "required":true,
+         "repeatable": true
       },
       "Contact-Name":{
          "required":true


### PR DESCRIPTION
Resolves #11 

* Fixes condition when assigning description text from bag profile json
* Adds test for `ProfileFieldRule#getDescription`
* Adds test for `ProfileFieldRule#getRepeatable`
* Adds test for `BagProfile.BuiltIn#from`