### PR TITLE
Write payload manifest checksums to tag manifests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,31 @@
-language: java
-sudo: false
-jdk: openjdk8
+jobs:
+  include:
+    - os: linux
+      jdk: openjdk8
+      language: java
+    - os: windows
+      language: shell
 
-os:
-  - linux
-  - windows
+env:
+  - MAVEN_VERSION=3.6.3
+  - JAVA_VERSION=8.242.8.1
 
 before_install:
-  - "echo $JAVA_OPTS"
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+      choco install openjdk8 --version ${JAVA_VERSION};
+      choco install maven --version ${MAVEN_VERSION}
+      export JAVA_HOME='/c/Program Files/OpenJDK/openjdk-${JAVA_VERSION}';
+      export MAVEN_HOME='/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin';
+      export PATH="${PATH}:${JAVA_HOME}:${MAVEN_HOME};
+    fi
+  - "echo ${PATH}"
+  - "mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=${MAVEN_VERSION}"
+
 
 script:
-  - mvn install -B -V
-  - mvn javadoc:jar
-  - mvn javadoc:test-aggregate
+  - ./mvnw install -B -V
+  - ./mvnw javadoc:jar
+  - ./mvnw javadoc:test-aggregate
 
 after_success:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ before_install:
       choco install openjdk8 --version ${JAVA_VERSION};
       echo "Installing maven ${MAVEN_VERSION};
       choco install maven --version ${MAVEN_VERSION};
-      export JAVA_HOME="/c/Program Files/OpenJDK/openjdk-8u242-b08/bin";
+      export JAVA_HOME="/c/Program Files/OpenJDK/openjdk-8u242-b08";
       export MAVEN_HOME="/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin";
-      export PATH="${PATH}:${JAVA_HOME}:${MAVEN_HOME}";
+      export PATH="${PATH}:${JAVA_HOME}/bin:${MAVEN_HOME}";
     fi
   - "echo ${PATH}"
   - "mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=${MAVEN_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ jobs:
       language: shell
 
 env:
-  - MAVEN_VERSION=3.6.3
-  - JAVA_VERSION=8.242.8.1
+  - MAVEN_VERSION=3.6.3 JAVA_VERSION=8.242.8.1
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
-      echo "Installing java ${JAVA_VERSION};
+      echo "Installing java ${JAVA_VERSION}";
       choco install openjdk8 --version ${JAVA_VERSION};
-      echo "Installing maven ${MAVEN_VERSION};
+      echo "Installing maven ${MAVEN_VERSION}";
       choco install maven --version ${MAVEN_VERSION};
       export JAVA_HOME="/c/Program Files/OpenJDK/openjdk-8u242-b08";
       export MAVEN_HOME="/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin";

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
       choco install openjdk8 --version ${JAVA_VERSION};
-      choco install maven --version ${MAVEN_VERSION}
+      choco install maven --version ${MAVEN_VERSION};
       export JAVA_HOME='/c/Program Files/OpenJDK/openjdk-${JAVA_VERSION}';
       export MAVEN_HOME='/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin';
       export PATH="${PATH}:${JAVA_HOME}:${MAVEN_HOME}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
       choco install openjdk8 --version ${JAVA_VERSION};
       choco install maven --version ${MAVEN_VERSION};
-      export JAVA_HOME='/c/Program Files/OpenJDK/openjdk-${JAVA_VERSION}';
-      export MAVEN_HOME='/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin';
+      export JAVA_HOME="/c/Program Files/OpenJDK/openjdk-${JAVA_VERSION}";
+      export MAVEN_HOME="/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin";
       export PATH="${PATH}:${JAVA_HOME}:${MAVEN_HOME}";
     fi
   - "echo ${PATH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ env:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+      echo "Installing java ${JAVA_VERSION};
       choco install openjdk8 --version ${JAVA_VERSION};
+      echo "Installing maven ${MAVEN_VERSION};
       choco install maven --version ${MAVEN_VERSION};
-      export JAVA_HOME="/c/Program Files/OpenJDK/openjdk-${JAVA_VERSION}";
+      export JAVA_HOME="/c/Program Files/OpenJDK/openjdk-8u242-b08";
       export MAVEN_HOME="/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin";
       export PATH="${PATH}:${JAVA_HOME}:${MAVEN_HOME}";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
       choco install maven --version ${MAVEN_VERSION}
       export JAVA_HOME='/c/Program Files/OpenJDK/openjdk-${JAVA_VERSION}';
       export MAVEN_HOME='/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin';
-      export PATH="${PATH}:${JAVA_HOME}:${MAVEN_HOME};
+      export PATH="${PATH}:${JAVA_HOME}:${MAVEN_HOME}";
     fi
   - "echo ${PATH}"
   - "mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=${MAVEN_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: java
 sudo: false
 jdk: openjdk8
 
+os:
+  - linux
+  - windows
+
 before_install:
   - "echo $JAVA_OPTS"
 
@@ -11,4 +15,4 @@ script:
   - mvn javadoc:test-aggregate
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
       choco install openjdk8 --version ${JAVA_VERSION};
       echo "Installing maven ${MAVEN_VERSION};
       choco install maven --version ${MAVEN_VERSION};
-      export JAVA_HOME="/c/Program Files/OpenJDK/openjdk-8u242-b08";
+      export JAVA_HOME="/c/Program Files/OpenJDK/openjdk-8u242-b08/bin";
       export MAVEN_HOME="/c/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin";
       export PATH="${PATH}:${JAVA_HOME}:${MAVEN_HOME}";
     fi

--- a/src/test/java/org/duraspace/bagit/BagWriterTest.java
+++ b/src/test/java/org/duraspace/bagit/BagWriterTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -164,4 +165,19 @@ public class BagWriterTest {
             fail("Unable to verify bag:\n" + e.getMessage());
         }
     }
+
+    @Test(expected = RuntimeException.class)
+    public void testAddInvalidAlgorithm() throws IOException {
+        // The message digests to use
+        final BagItDigest sha1 = BagItDigest.SHA1;
+        final BagItDigest sha256 = BagItDigest.SHA256;
+
+        // Create a writer with 3 manifest algorithms
+        Files.createDirectories(bag);
+        final BagWriter writer = new BagWriter(bag.toFile(), Sets.newHashSet(sha1));
+
+        // we don't need to pass any files, just the errant BagItDigest
+        writer.registerChecksums(sha256, Collections.emptyMap());
+    }
+
 }

--- a/src/test/java/org/duraspace/bagit/BagWriterTest.java
+++ b/src/test/java/org/duraspace/bagit/BagWriterTest.java
@@ -142,6 +142,12 @@ public class BagWriterTest {
         final List<String> extraLines = Files.readAllLines(extra);
         assertThat(extraLines).contains("test-key: test-value");
 
+        // Assert that tagmanifest-*.txt contains the manifest checksums
+        final List<String> sha1TagLines = Files.readAllLines(sha1Tagmanifest);
+        assertThat(sha1TagLines).anySatisfy(entry -> {
+            assertThat(entry).containsPattern("manifest-sha1.txt|manifest-sha256.txt|manifest-sha512.txt");
+        });
+
         // Finally, pass BagProfile validation and BagIt validation
         final BagReader reader = new BagReader();
         final BagVerifier verifier = new BagVerifier();


### PR DESCRIPTION
Resolves: #10 

This updates the `BagWriter` to write the checksums for payload manifests to each of the tag manifests.

The biggest change for this is that it updates the logic for creating the checksums - instead of having many `MessageDigest` instances in the `BagWriter`, the `OutputStream` for a file is wrapped using `DigestOutputStream`s. These pass the contents being written to the `OutputStream` which they were created with, so they do not impact the writing of the file itself or interfere with any other digests. This is handled by the `streamFor` method and an addition field `activeStreams` which keeps track of the ongoing checksums. 