### PR TITLE
Preserve ordering of bagit.txt entries

### DIFF
--- a/src/main/java/org/duraspace/bagit/BagWriter.java
+++ b/src/main/java/org/duraspace/bagit/BagWriter.java
@@ -21,6 +21,7 @@ import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Utility to write BagIt bags.
@@ -60,7 +61,7 @@ public class BagWriter {
         tagFileRegistry = new HashMap<>();
         tagRegistry = new HashMap<>();
 
-        final Map<String, String> bagitValues = new HashMap<>();
+        final Map<String, String> bagitValues = new TreeMap<>();
         bagitValues.put("BagIt-Version", BAGIT_VERSION);
         bagitValues.put("Tag-File-Character-Encoding", "UTF-8");
         tagRegistry.put("bagit.txt", bagitValues);

--- a/src/test/java/org/duraspace/bagit/BagWriterTest.java
+++ b/src/test/java/org/duraspace/bagit/BagWriterTest.java
@@ -132,7 +132,7 @@ public class BagWriterTest {
 
         // Assert that bagit.txt contains expected lines
         final List<String> bagitLines = Files.readAllLines(bagit);
-        assertThat(bagitLines).contains("BagIt-Version: 0.97", "Tag-File-Character-Encoding: UTF-8");
+        assertThat(bagitLines).containsSequence("BagIt-Version: 0.97", "Tag-File-Character-Encoding: UTF-8");
 
         // Assert that bag-info.txt contains... the bare necessities
         final List<String> bagInfoLines = Files.readAllLines(bagInfo);


### PR DESCRIPTION
Resolves #19 

Use a `TreeMap` to store ordering of entries for the `bagit.txt`
Update the `BagWriterTest` to check that the expected ordering occurs