### PR TITLE
Fix regex matching for readInfo

### DIFF
--- a/src/main/java/org/duraspace/bagit/ProfileValidationUtil.java
+++ b/src/main/java/org/duraspace/bagit/ProfileValidationUtil.java
@@ -210,16 +210,18 @@ public class ProfileValidationUtil {
      */
     private static Map<String, String> readInfo(final Path info) throws IOException {
         logger.debug("Trying to read info file {}", info);
+        final Pattern colon = Pattern.compile(":");
+        final Pattern space = Pattern.compile("^\\s+");
         final Map<String, String> data = new HashMap<>();
         final AtomicReference<String> previousKey = new AtomicReference<>("");
 
         // if a line starts indented, it is part of the previous key so we track what key we're working on
         try (Stream<String> lines = Files.lines(info)) {
             lines.forEach(line -> {
-                if (line.matches("^\\s+")) {
-                    data.merge(previousKey.get(), line, String::concat);
+                if (space.matcher(line).find()) {
+                    data.merge(previousKey.get(), line.trim(), String::concat);
                 } else {
-                    final String[] split = line.split(":");
+                    final String[] split = colon.split(line, 2);
                     final String key = split[0].trim();
                     final String value = split[1].trim();
                     previousKey.set(key);

--- a/src/test/java/org/duraspace/bagit/ProfileValidationUtilTest.java
+++ b/src/test/java/org/duraspace/bagit/ProfileValidationUtilTest.java
@@ -101,7 +101,10 @@ public class ProfileValidationUtilTest {
     public void testOnDiskInfoValidation() throws ProfileValidationException, IOException {
         rules.clear();
         rules.put("Source-Organization",
-                  new ProfileFieldRule(required, repeatable, recommended, "", Collections.emptySet()));
+                  new ProfileFieldRule(required, repeatable, recommended, "", Collections.singleton("bagit-support")));
+        rules.put("Organization-Address",
+                  new ProfileFieldRule(required, repeatable, recommended, "",
+                                       Collections.singleton("localhost-dot-localdomain")));
         final String bagInfoPath = "src/test/resources/sample/bag/bag-info.txt";
         ProfileValidationUtil.validate("profile-section", rules, Paths.get(bagInfoPath));
     }

--- a/src/test/java/org/duraspace/bagit/ProfileValidationUtilTest.java
+++ b/src/test/java/org/duraspace/bagit/ProfileValidationUtilTest.java
@@ -5,7 +5,6 @@
 package org.duraspace.bagit;
 
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
@@ -102,10 +101,7 @@ public class ProfileValidationUtilTest {
     public void testOnDiskInfoValidation() throws ProfileValidationException, IOException {
         rules.clear();
         rules.put("Source-Organization",
-                  new ProfileFieldRule(required, repeatable, recommended, "", Collections.singleton("bagit-support")));
-        rules.put("Organization-Address",
-                  new ProfileFieldRule(required, repeatable, recommended, "",
-                                       Collections.singleton("localhost-dot-localdomain")));
+                  new ProfileFieldRule(required, repeatable, recommended, "", Collections.emptySet()));
         final String bagInfoPath = "src/test/resources/sample/bag/bag-info.txt";
         ProfileValidationUtil.validate("profile-section", rules, Paths.get(bagInfoPath));
     }

--- a/src/test/java/org/duraspace/bagit/ProfileValidationUtilTest.java
+++ b/src/test/java/org/duraspace/bagit/ProfileValidationUtilTest.java
@@ -5,6 +5,7 @@
 package org.duraspace.bagit;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,7 +102,10 @@ public class ProfileValidationUtilTest {
     public void testOnDiskInfoValidation() throws ProfileValidationException, IOException {
         rules.clear();
         rules.put("Source-Organization",
-                  new ProfileFieldRule(required, repeatable, recommended, "", Collections.emptySet()));
+                  new ProfileFieldRule(required, repeatable, recommended, "", Collections.singleton("bagit-support")));
+        rules.put("Organization-Address",
+                  new ProfileFieldRule(required, repeatable, recommended, "",
+                                       Collections.singleton("localhost-dot-localdomain")));
         final String bagInfoPath = "src/test/resources/sample/bag/bag-info.txt";
         ProfileValidationUtil.validate("profile-section", rules, Paths.get(bagInfoPath));
     }

--- a/src/test/resources/sample/bag/bag-info.txt
+++ b/src/test/resources/sample/bag/bag-info.txt
@@ -2,6 +2,7 @@ Bag-Size : 4 KB
 Payload-Oxum : 4096.1
 Bagging-Date : 2016-12-13
 Source-Organization: bagit-support
-Organization-Address: localhost
+Organization-Address: localhost-
+  dot-localdomain
 Contact-Name: test-user
 Contact-Phone: phone-number


### PR DESCRIPTION
Resolves #16 

Use `find` instead of `match` to test if a line is an extended tag value