### PR TITLE
BagProfile Improvements

### DIFF
--- a/src/main/java/org/duraspace/bagit/BagProfile.java
+++ b/src/main/java/org/duraspace/bagit/BagProfile.java
@@ -452,8 +452,8 @@ public class BagProfile {
     /**
      * Validate a configuration for tag files based on a mapping of BagIt tag filenames to key-value pairs.
      *
-     * e.g. the filename "bag-info.txt" could contain the pairs "Source-Organization" -> "DuraSpace" and
-     * "Organization-Address" -> "The Cloud"
+     * e.g. the filename "bag-info.txt" could contain the pairs "Source-Organization: DuraSpace" and
+     * "Organization-Address: The Cloud"
      *
      * @param config the Map containing the configuration of BagIt tag files
      */

--- a/src/main/java/org/duraspace/bagit/BagProfile.java
+++ b/src/main/java/org/duraspace/bagit/BagProfile.java
@@ -138,7 +138,6 @@ public class BagProfile {
     private Set<String> payloadDigestAlgorithms;
     private Set<String> tagDigestAlgorithms;
 
-    private Set<String> sections = new HashSet<>();
     private Map<String, Map<String, ProfileFieldRule>> metadataFields = new HashMap<>();
     private Map<String, String> profileMetadata = new HashMap<>();
 
@@ -189,7 +188,6 @@ public class BagProfile {
         tagDigestAlgorithms = arrayValues(json, TAG_MANIFESTS_REQUIRED);
 
         metadataFields.put(BAG_INFO.toLowerCase(), metadataFields(json.get(BAG_INFO)));
-        sections.add(BAG_INFO.toLowerCase());
 
         if (json.get(OTHER_INFO) != null) {
             loadOtherTags(json);
@@ -213,12 +211,10 @@ public class BagProfile {
                 while (fields.hasNext()) {
                     final Map.Entry<String, JsonNode> entry = fields.next();
                     final String tagName = entry.getKey().toLowerCase();
-                    sections.add(tagName);
                     metadataFields.put(tagName, metadataFields(entry.getValue()));
                 }
             }
         }
-        logger.debug("tagFiles is {}", sections);
         logger.debug("metadataFields is {}", metadataFields);
     }
 
@@ -426,7 +422,7 @@ public class BagProfile {
      * @return set of section names
      */
     public Set<String> getSectionNames() {
-        return sections;
+        return metadataFields.keySet();
     }
 
     /**
@@ -528,7 +524,7 @@ public class BagProfile {
         }
 
         // check *-info required fields
-        for (String section : sections) {
+        for (String section : metadataFields.keySet()) {
             final String tagFile = section.toLowerCase() + ".txt";
             final Path resolved = root.resolve(tagFile);
             try {

--- a/src/main/java/org/duraspace/bagit/BagProfile.java
+++ b/src/main/java/org/duraspace/bagit/BagProfile.java
@@ -446,23 +446,31 @@ public class BagProfile {
      * @param config the BagConfig
      */
     public void validateConfig(final BagConfig config) {
+        final HashMap<String, Map<String, String>> tagMap = new HashMap<>();
+        config.getTagFiles().forEach(tag -> tagMap.put(tag, config.getFieldsForTagFile(tag)));
+        validateTags(tagMap);
+    }
+
+    /**
+     * Validate a set of tag files
+     *
+     * @param tags A mapping of tag file names and their fields to validate
+     */
+    public void validateTags(final Map<String, Map<String, String>> tags) {
         for (final String section : sections) {
             final String tagFile = section.toLowerCase() + ".txt";
-            if (config.hasTagFile(tagFile)) {
+            if (tags.containsKey(tagFile)) {
                 try {
-                    ProfileValidationUtil.validate(section, getMetadataFields(section),
-                                                   config.getFieldsForTagFile(tagFile));
-
+                    ProfileValidationUtil.validate(section, getMetadataFields(section), tags.get(tagFile));
                     ProfileValidationUtil.validateTagIsAllowed(Paths.get(tagFile), tagFilesAllowed);
                 } catch (ProfileValidationException e) {
                     throw new RuntimeException(e.getMessage(), e);
                 }
             } else {
-                throw new RuntimeException(String.format("Error missing section %s from bag config", section));
+                throw new RuntimeException(String.format("Error missing section %s", section));
             }
         }
     }
-
 
     /**
      * Validate a given {@link Bag} against the current profile

--- a/src/main/java/org/duraspace/bagit/BagProfile.java
+++ b/src/main/java/org/duraspace/bagit/BagProfile.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.loc.repository.bagit.domain.Bag;
 import gov.loc.repository.bagit.domain.Manifest;
+import org.slf4j.Logger;
 
 /**
  * A BagProfile contains the entire contents of a BagIt profile specified through the profile's json.
@@ -187,8 +188,8 @@ public class BagProfile {
         payloadDigestAlgorithms = arrayValues(json, MANIFESTS_REQUIRED);
         tagDigestAlgorithms = arrayValues(json, TAG_MANIFESTS_REQUIRED);
 
-        metadataFields.put(BAG_INFO, metadataFields(json.get(BAG_INFO)));
-        sections.add(BAG_INFO);
+        metadataFields.put(BAG_INFO.toLowerCase(), metadataFields(json.get(BAG_INFO)));
+        sections.add(BAG_INFO.toLowerCase());
 
         if (json.get(OTHER_INFO) != null) {
             loadOtherTags(json);
@@ -211,7 +212,7 @@ public class BagProfile {
                 final Iterator<Map.Entry<String, JsonNode>> fields = entries.fields();
                 while (fields.hasNext()) {
                     final Map.Entry<String, JsonNode> entry = fields.next();
-                    final String tagName = entry.getKey();
+                    final String tagName = entry.getKey().toLowerCase();
                     sections.add(tagName);
                     metadataFields.put(tagName, metadataFields(entry.getValue()));
                 }
@@ -416,7 +417,7 @@ public class BagProfile {
      * @return map of tag = set of acceptable values, or null if tagFile doesn't exist
      */
     public Map<String, ProfileFieldRule> getMetadataFields(final String tagFile) {
-        return metadataFields.get(tagFile);
+        return metadataFields.get(tagFile.toLowerCase());
     }
 
     /**

--- a/src/main/java/org/duraspace/bagit/BagProfile.java
+++ b/src/main/java/org/duraspace/bagit/BagProfile.java
@@ -494,7 +494,7 @@ public class BagProfile {
         // the main pattern: two groups - a wildcard matcher for the filename and the tag suffix
         // the replacement: just the first capture group
         final String replacement = "$1";
-        final Pattern tagEnding = Pattern.compile("(.*)(\\.txt)");
+        final Pattern tagEnding = Pattern.compile("(.*)(\\" + BAGIT_TAG_SUFFIX + ")");
         final Matcher matcher = tagEnding.matcher(filename.toLowerCase());
         return matcher.replaceAll(replacement);
     }
@@ -558,7 +558,7 @@ public class BagProfile {
 
         // check *-info required fields
         for (String section : metadataFields.keySet()) {
-            final String tagFile = section.toLowerCase() + ".txt";
+            final String tagFile = section.toLowerCase() + BAGIT_TAG_SUFFIX;
             final Path resolved = root.resolve(tagFile);
             try {
                 ProfileValidationUtil.validate(section, metadataFields.get(section), resolved);

--- a/src/main/java/org/duraspace/bagit/BagProfile.java
+++ b/src/main/java/org/duraspace/bagit/BagProfile.java
@@ -450,11 +450,24 @@ public class BagProfile {
     }
 
     /**
+     * Validate a configuration for tag files based on a mapping of BagIt tag filenames to key-value pairs.
+     *
+     * e.g. the filename "bag-info.txt" could contain the pairs "Source-Organization" -> "DuraSpace" and
+     * "Organization-Address" -> "The Cloud"
+     *
+     * @param config the Map containing the configuration of BagIt tag files
+     */
+    public void validateTagFiles(final Map<String, Map<String, String>> config) {
+        checkRequiredTagsExist(config.keySet());
+        config.forEach(this::validateTag);
+    }
+
+    /**
      * Test that all required tag files exist
      *
      * @param tags the name of each tag file to check
      */
-    public void checkRequiredTagsExist(final Set<String> tags) {
+    private void checkRequiredTagsExist(final Set<String> tags) {
         for (String section : metadataFields.keySet()) {
             final String expected = section + BAGIT_TAG_SUFFIX;
             if (!tags.contains(expected)) {
@@ -469,7 +482,7 @@ public class BagProfile {
      * @param filename the name of the tag file to validate
      * @param fields A mapping of tag file names and their fields to validate
      */
-    public void validateTag(final String filename, final Map<String, String> fields) {
+    private void validateTag(final String filename, final Map<String, String> fields) {
         // strip the trailing file extension
         final String section = getSection(filename);
         logger.debug("Checking validation for {}", section);

--- a/src/main/java/org/duraspace/bagit/BagProfileConstants.java
+++ b/src/main/java/org/duraspace/bagit/BagProfileConstants.java
@@ -25,7 +25,6 @@ public abstract class BagProfileConstants {
     public static final String BAGIT_PROFILE_IDENTIFIER = "BagIt-Profile-Identifier";
 
     // misc
-
     public static final String BAGIT_TAG_SUFFIX = ".txt";
     public static final String BAGIT_MD5 = "md5";
     public static final String BAGIT_SHA1 = "sha1";

--- a/src/main/java/org/duraspace/bagit/BagProfileConstants.java
+++ b/src/main/java/org/duraspace/bagit/BagProfileConstants.java
@@ -24,6 +24,9 @@ public abstract class BagProfileConstants {
     public static final String BAGIT_PROFILE_VERSION = "BagIt-Profile-Version";
     public static final String BAGIT_PROFILE_IDENTIFIER = "BagIt-Profile-Identifier";
 
+    // misc
+
+    public static final String BAGIT_TAG_SUFFIX = ".txt";
     public static final String BAGIT_MD5 = "md5";
     public static final String BAGIT_SHA1 = "sha1";
     public static final String BAGIT_SHA_256 = "sha256";

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -4,6 +4,7 @@
  */
 package org.duraspace.bagit;
 
+import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.duraspace.bagit.BagConfig.ACCESS_KEY;
 import static org.duraspace.bagit.BagConfig.BAGGING_DATE_KEY;
@@ -44,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import gov.loc.repository.bagit.domain.Bag;
 import gov.loc.repository.bagit.domain.FetchItem;
@@ -178,8 +181,12 @@ public class BagProfileTest {
     @Test
     public void testGoodConfig() throws Exception {
         final BagConfig config = new BagConfig(resolveResourcePath(bagitConfig).toFile());
+        final Map<String, Map<String, String>> configAsMap =
+            config.getTagFiles().stream()
+                  .collect(Collectors.toMap(identity(), config::getFieldsForTagFile));
         final BagProfile profile = new BagProfile(Files.newInputStream(resolveResourcePath(extraTagsPath)));
         profile.validateConfig(config);
+        profile.validateTagFiles(configAsMap);
     }
 
     @Test(expected = RuntimeException.class)

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import gov.loc.repository.bagit.domain.Bag;

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -28,6 +28,7 @@ import static org.duraspace.bagit.BagProfileConstants.TAG_FILES_REQUIRED;
 import static org.duraspace.bagit.BagProfileConstants.TAG_MANIFESTS_REQUIRED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -147,6 +148,15 @@ public class BagProfileTest {
         assertTrue(profile.getTagFilesRequired().isEmpty());
         assertTrue(profile.getAllowedTagAlgorithms().isEmpty());
         assertTrue(profile.getAllowedPayloadAlgorithms().isEmpty());
+    }
+
+    @Test
+    public void testLoadsEmptyMap() throws URISyntaxException, IOException {
+        final String profilePath = "profiles/profileNoBagInfo.json";
+        final BagProfile profile = new BagProfile(Files.newInputStream(resolveResourcePath(profilePath)));
+        final Map<String, ProfileFieldRule> bagInfoFields = profile.getMetadataFields(BAG_INFO);
+        assertNotNull(bagInfoFields);
+        assertTrue(bagInfoFields.isEmpty());
     }
 
     @Test

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -131,6 +131,11 @@ public class BagProfileTest {
         assertTrue(profile.getMetadataFields().get(PAYLOAD_OXUM_KEY).isRequired());
         assertFalse(profile.getMetadataFields().get(CONTACT_EMAIL_KEY).isRequired());
 
+        assertTrue(profile.getMetadataFields().get(BAGIT_PROFILE_IDENTIFIER).isRepeatable());
+        assertFalse(profile.getMetadataFields().get(BAGIT_PROFILE_IDENTIFIER).isRequired());
+        assertFalse(profile.getMetadataFields().get(BAGIT_PROFILE_IDENTIFIER).isRecommended());
+        assertEquals(profile.getMetadataFields().get(BAGIT_PROFILE_IDENTIFIER).getDescription(), "No description");
+
         assertTrue(profile.getSectionNames().stream().allMatch(t -> t.equalsIgnoreCase(BAG_INFO)));
 
         assertFalse(profile.isAllowFetch());

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -150,8 +150,8 @@ public class BagProfileTest {
         final BagProfile profile = new BagProfile(Files.newInputStream(resolveResourcePath(extraTagsPath)));
 
         assertTrue(profile.getSectionNames().stream().anyMatch(t -> t.equalsIgnoreCase(BAG_INFO)));
-        assertTrue(profile.getSectionNames().stream().anyMatch(t -> t.equals(aptrustInfo)));
-        assertTrue(profile.getSectionNames().stream().noneMatch(t -> t.equals("Wrong-Tags")));
+        assertTrue(profile.getSectionNames().stream().anyMatch(t -> t.equalsIgnoreCase(aptrustInfo)));
+        assertTrue(profile.getSectionNames().stream().noneMatch(t -> t.equalsIgnoreCase("Wrong-Tags")));
         assertTrue(profile.getMetadataFields(aptrustInfo).containsKey(TITLE_KEY));
         assertTrue(profile.getMetadataFields(aptrustInfo).containsKey(ACCESS_KEY));
         assertTrue(profile.getMetadataFields(aptrustInfo).get(ACCESS_KEY).getValues().contains("Consortia"));

--- a/src/test/resources/profiles/profile.json
+++ b/src/test/resources/profiles/profile.json
@@ -53,6 +53,10 @@
       },
       "Payload-Oxum":{
          "required":true
+      },
+      "BagIt-Profile-Identifier": {
+         "recommended": false,
+         "description": ""
       }
    },
    "Manifests-Required":[

--- a/src/test/resources/profiles/profileNoBagInfo.json
+++ b/src/test/resources/profiles/profileNoBagInfo.json
@@ -1,0 +1,30 @@
+{
+   "BagIt-Profile-Info":{
+      "BagIt-Profile-Identifier":"http://fedora.info/profile.json",
+      "BagIt-Profile-Version":"1.3.0",
+      "Source-Organization":"Duraspace",
+      "Contact-Name":"Fedo Radmin",
+      "Contact-Email":"fedo@example.org",
+      "External-Description":"Test Bag Profile for Fedora.",
+      "Version":"0.2"
+   },
+   "Manifests-Required":[
+      "md5", "sha1", "sha256", "sha512"
+   ],
+   "Manifests-Allowed": [],
+   "Allow-Fetch.txt":false,
+   "Serialization":"optional",
+   "Accept-Serialization": [
+      "application/tar"
+   ],
+   "Tag-Manifests-Required":[
+     "sha1", "sha256", "sha512"
+   ],
+   "Tag-Manifests-Allowed": [],
+   "Tag-Files-Required": [],
+   "Tag-Files-Allowed": ["*"],
+   "Accept-BagIt-Version":[
+      "0.97",
+      "1.0"
+   ]
+}


### PR DESCRIPTION
Resolves #18 

* Simplify initialization logic for `metadataFields`
* Coerce info sections for BagProfiles to be lower-case
* Add method for validating a tag file by its filename and a Map of key-value pairs
* Add method for validating all tag files exist based on a Set of String filenames