### PR TITLE
Simplify tar mappings

### DIFF
--- a/src/main/java/org/duraspace/bagit/SerializationSupport.java
+++ b/src/main/java/org/duraspace/bagit/SerializationSupport.java
@@ -69,8 +69,8 @@ public class SerializationSupport {
         commonTypeMap.put("tar", APPLICATION_TAR);
         commonTypeMap.put(APPLICATION_TAR, APPLICATION_TAR);
         commonTypeMap.put(APPLICATION_GTAR, APPLICATION_TAR);
-        commonTypeMap.put(APPLICATION_X_TAR, APPLICATION_X_TAR);
-        commonTypeMap.put(APPLICATION_X_GTAR, APPLICATION_X_TAR);
+        commonTypeMap.put(APPLICATION_X_TAR, APPLICATION_TAR);
+        commonTypeMap.put(APPLICATION_X_GTAR, APPLICATION_TAR);
 
         commonTypeMap.put("tgz", APPLICATION_GZIP);
         commonTypeMap.put("gzip", APPLICATION_GZIP);

--- a/src/main/java/org/duraspace/bagit/SerializationSupport.java
+++ b/src/main/java/org/duraspace/bagit/SerializationSupport.java
@@ -28,18 +28,18 @@ public class SerializationSupport {
     private static final Logger logger = LoggerFactory.getLogger(SerializationSupport.class);
 
     // zip
-    private static final String APPLICATION_ZIP = "application/zip";
+    protected static final String APPLICATION_ZIP = "application/zip";
 
     // tar + gtar
-    private static final String APPLICATION_TAR = "application/tar";
-    private static final String APPLICATION_GTAR = "application/gtar";
-    private static final String APPLICATION_X_TAR = "application/x-tar";
-    private static final String APPLICATION_X_GTAR = "application/x-gtar";
+    protected static final String APPLICATION_TAR = "application/tar";
+    protected static final String APPLICATION_GTAR = "application/gtar";
+    protected static final String APPLICATION_X_TAR = "application/x-tar";
+    protected static final String APPLICATION_X_GTAR = "application/x-gtar";
 
     // gzip
-    private static final String APPLICATION_GZIP = "application/gzip";
-    private static final String APPLICATION_X_GZIP = "application/x-gzip";
-    private static final String APPLICATION_X_COMPRESSED_TAR = "application/x-compressed-tar";
+    protected static final String APPLICATION_GZIP = "application/gzip";
+    protected static final String APPLICATION_X_GZIP = "application/x-gzip";
+    protected static final String APPLICATION_X_COMPRESSED_TAR = "application/x-compressed-tar";
 
     public static final Set<String> ZIP_TYPES = Collections.singleton(APPLICATION_ZIP);
     public static final Set<String> TAR_TYPES = new HashSet<>(Arrays.asList(APPLICATION_TAR, APPLICATION_X_TAR,
@@ -79,6 +79,16 @@ public class SerializationSupport {
         commonTypeMap.put(APPLICATION_X_GZIP, APPLICATION_GZIP);
         commonTypeMap.put(APPLICATION_X_COMPRESSED_TAR, APPLICATION_GZIP);
         return commonTypeMap;
+    }
+
+    /**
+     * Visible for testing only
+     * Retrieve a copy of the commonTypeMap
+     *
+     * @return a copy of the commonTypeMap
+     */
+    protected static Map<String, String> getCommonTypeMap() {
+        return new HashMap<>(commonTypeMap);
     }
 
     /**

--- a/src/main/java/org/duraspace/bagit/SerializationSupport.java
+++ b/src/main/java/org/duraspace/bagit/SerializationSupport.java
@@ -129,9 +129,8 @@ public class SerializationSupport {
             }
         }
 
-        // todo: format list correctly
         throw new RuntimeException("BagProfile does not allow " + contentType + ". Accepted serializations are:\n" +
-                profile.getAcceptedSerializations());
+                                   profile.getAcceptedSerializations());
     }
 
     /**
@@ -152,10 +151,11 @@ public class SerializationSupport {
                 return new TarBagSerializer();
             } else if (GZIP_TYPES.contains(type)) {
                 return new TarGzBagSerializer();
+            } else {
+                throw new UnsupportedOperationException("Unsupported content type " + contentType);
             }
         }
 
-        // todo: proper formatting of list
         throw new RuntimeException("BagProfile does not allow " + type + ". Accepted serializations are:\n" +
                                    profile.getAcceptedSerializations());
     }

--- a/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
+++ b/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
@@ -16,6 +16,7 @@ import static org.duraspace.bagit.SerializationSupport.APPLICATION_ZIP;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -100,12 +101,33 @@ public class SerializationSupportTest {
         SerializationSupport.deserializerFor(notSupported, profile);
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testDeserializationNotSupported() throws Exception {
+        // A deserialization format which exists in a profile, but not by bagit-support
+        // currently json because we have many json resources available
+        final URL profileUrl = SerializationSupportTest.class.getClassLoader().getResource("profiles/profile.json");
+        assertThat(profileUrl).isNotNull();
+        final Path profileJson = Paths.get(profileUrl.toURI());
+        final BagProfile profile = new BagProfile(Files.newInputStream(profileJson));
+
+        SerializationSupport.deserializerFor(profileJson, profile);
+    }
+
     @Test(expected = RuntimeException.class)
-    public void testSerializerNotSupported() throws IOException {
+    public void testSerializerNoProfileSupport() throws IOException {
         // A serialization/compression format which does not exist in the profile, currently xz
         final String xz = "application/x-xz";
         final BagProfile profile = new BagProfile(BagProfile.BuiltIn.DEFAULT);
         SerializationSupport.serializerFor(xz, profile);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSerializerNotSupported() throws IOException {
+        // A serialization/compression format which exists in a profile, but not by bagit-support
+        // currently 7zip fits this
+        final String sevenZip = "application/x-7z-compressed";
+        final BagProfile profile = new BagProfile(BagProfile.BuiltIn.BEYOND_THE_REPOSITORY);
+        SerializationSupport.serializerFor(sevenZip, profile);
     }
 
 }

--- a/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
+++ b/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
@@ -1,0 +1,83 @@
+/*
+ * The contents of this file are subject to the license and copyright detailed
+ * in the LICENSE and NOTICE files at the root of the source tree.
+ */
+package org.duraspace.bagit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.duraspace.bagit.SerializationSupport.APPLICATION_GTAR;
+import static org.duraspace.bagit.SerializationSupport.APPLICATION_GZIP;
+import static org.duraspace.bagit.SerializationSupport.APPLICATION_TAR;
+import static org.duraspace.bagit.SerializationSupport.APPLICATION_X_COMPRESSED_TAR;
+import static org.duraspace.bagit.SerializationSupport.APPLICATION_X_GTAR;
+import static org.duraspace.bagit.SerializationSupport.APPLICATION_X_GZIP;
+import static org.duraspace.bagit.SerializationSupport.APPLICATION_X_TAR;
+import static org.duraspace.bagit.SerializationSupport.APPLICATION_ZIP;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Verify our type mappings are what we expect
+ *
+ * all zip types map to application/zip
+ * all tar types map to application/tar
+ * all gzip types map to application/gzip
+ *
+ * @author mikejritter
+ */
+public class SerializationSupportTest {
+
+    private final Map<String, String> commonTypeMap = SerializationSupport.getCommonTypeMap();
+
+    @Test
+    public void testZipMappings() {
+        final String zipIdentifier = "zip";
+
+        assertThat(commonTypeMap).hasEntrySatisfying(zipIdentifier,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_ZIP));
+
+        assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_ZIP,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_ZIP));
+    }
+
+    @Test
+    public void testTarMappings() {
+        final String tarIdentifier = "tar";
+
+        assertThat(commonTypeMap).hasEntrySatisfying(tarIdentifier,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_TAR));
+        assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_TAR,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_TAR));
+        assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_X_TAR,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_TAR));
+        assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_GTAR,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_TAR));
+        assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_X_GTAR,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_TAR));
+    }
+
+
+    @Test
+    public void testGZipMappings() {
+        final String tgzIdentifier = "tgz";
+        final String gzipIdentifier = "gzip";
+        final String tarGzIdentifier = "tar+gz";
+
+        assertThat(commonTypeMap).hasEntrySatisfying(tgzIdentifier,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
+        assertThat(commonTypeMap).hasEntrySatisfying(gzipIdentifier,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
+        assertThat(commonTypeMap).hasEntrySatisfying(tarGzIdentifier,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
+        assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_GZIP,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
+        assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_X_GZIP,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
+        assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_X_COMPRESSED_TAR,
+                                                     value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
+
+    }
+
+}

--- a/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
+++ b/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
@@ -37,7 +37,6 @@ public class SerializationSupportTest {
 
         assertThat(commonTypeMap).hasEntrySatisfying(zipIdentifier,
                                                      value -> assertThat(value).isEqualTo(APPLICATION_ZIP));
-
         assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_ZIP,
                                                      value -> assertThat(value).isEqualTo(APPLICATION_ZIP));
     }
@@ -58,7 +57,6 @@ public class SerializationSupportTest {
                                                      value -> assertThat(value).isEqualTo(APPLICATION_TAR));
     }
 
-
     @Test
     public void testGZipMappings() {
         final String tgzIdentifier = "tgz";
@@ -77,7 +75,6 @@ public class SerializationSupportTest {
                                                      value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
         assertThat(commonTypeMap).hasEntrySatisfying(APPLICATION_X_COMPRESSED_TAR,
                                                      value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
-
     }
 
 }

--- a/src/test/resources/profiles/profile.json
+++ b/src/test/resources/profiles/profile.json
@@ -66,7 +66,8 @@
    "Allow-Fetch.txt":false,
    "Serialization":"optional",
    "Accept-Serialization": [
-      "application/tar"
+      "application/tar",
+      "application/json"
    ],
    "Tag-Manifests-Required":[
      "sha1", "sha256", "sha512"


### PR DESCRIPTION
Resolves #31 

Update the type mappings for `application/x-tar` to map to `application/tar`, as they are functionally the same