### PR TITLE
Support separate payload and tag manifest checksums

### DIFF
--- a/src/main/java/org/duraspace/bagit/BagWriter.java
+++ b/src/main/java/org/duraspace/bagit/BagWriter.java
@@ -52,24 +52,7 @@ public class BagWriter {
      * @param algorithms Set of digest algorithms to use for manifests (e.g., "md5", "sha1", or "sha256")
      */
     public BagWriter(final File bagDir, final Set<BagItDigest> algorithms) {
-        this.bagDir = bagDir;
-        this.dataDir = new File(bagDir, "data");
-        if (!dataDir.exists()) {
-            dataDir.mkdirs();
-        }
-
-        this.tagAlgorithms = algorithms;
-        this.payloadAlgorithms = algorithms;
-        payloadRegistry = new HashMap<>();
-        tagFileRegistry = new HashMap<>();
-        tagRegistry = new HashMap<>();
-
-        final Map<String, String> bagitValues = new TreeMap<>();
-        bagitValues.put("BagIt-Version", BAGIT_VERSION);
-        bagitValues.put("Tag-File-Character-Encoding", "UTF-8");
-        tagRegistry.put("bagit.txt", bagitValues);
-
-        activeStreams = new HashMap<>();
+        this(bagDir, algorithms, algorithms);
     }
 
     /**

--- a/src/main/java/org/duraspace/bagit/BagWriter.java
+++ b/src/main/java/org/duraspace/bagit/BagWriter.java
@@ -28,6 +28,8 @@ public class BagWriter {
 
     private File bagDir;
     private File dataDir;
+    private Set<BagItDigest> tagAlgorithms;
+    private Set<BagItDigest> payloadAlgorithms;
     private Set<BagItDigest> algorithms;
 
     private Map<BagItDigest, Map<File, String>> payloadRegistry;
@@ -57,6 +59,38 @@ public class BagWriter {
             dataDir.mkdirs();
         }
 
+        this.algorithms = algorithms;
+        this.tagAlgorithms = algorithms;
+        this.payloadAlgorithms = algorithms;
+        payloadRegistry = new HashMap<>();
+        tagFileRegistry = new HashMap<>();
+        tagRegistry = new HashMap<>();
+
+        final Map<String, String> bagitValues = new TreeMap<>();
+        bagitValues.put("BagIt-Version", BAGIT_VERSION);
+        bagitValues.put("Tag-File-Character-Encoding", "UTF-8");
+        tagRegistry.put("bagit.txt", bagitValues);
+
+        activeStreams = new HashMap<>();
+    }
+
+    /**
+     * Create a new, empty Bag
+     *
+     * @param bagDir The base directory for the Bag (will be created if it doesn't exist)
+     * @param payloadAlgorithms Set of digest algorithms to use for payload manifests (e.g., "md5", "sha1", or "sha256")
+     * @param tagAlgorithms Set of digest algorithms to use for tag manifests (e.g., "md5", "sha1", or "sha256")
+     */
+    public BagWriter(final File bagDir, final Set<BagItDigest> payloadAlgorithms,
+                     final Set<BagItDigest> tagAlgorithms) {
+        this.bagDir = bagDir;
+        this.dataDir = new File(bagDir, "data");
+        if (!dataDir.exists()) {
+            dataDir.mkdirs();
+        }
+
+        this.tagAlgorithms = tagAlgorithms;
+        this.payloadAlgorithms = payloadAlgorithms;
         this.algorithms = algorithms;
         payloadRegistry = new HashMap<>();
         tagFileRegistry = new HashMap<>();

--- a/src/test/java/org/duraspace/bagit/BagWriterTest.java
+++ b/src/test/java/org/duraspace/bagit/BagWriterTest.java
@@ -145,8 +145,8 @@ public class BagWriterTest {
             .contains("test-key: test-value", "additional-key: additional-value");
 
         // Assert that tagmanifest-{sha1,sha256,sha512}.txt contain the manifest checksums
-        tagFilesContain(Sets.newHashSet(sha1Tagmanifest, sha256Tagmanifest, sha512Tagmanifest),
-                        Sets.newHashSet(sha1, sha256, sha512));
+        tagManifestsContain(Sets.newHashSet(sha1Tagmanifest, sha256Tagmanifest, sha512Tagmanifest),
+                            Sets.newHashSet(sha1, sha256, sha512));
 
         // Finally, pass BagProfile validation and BagIt validation
         validateBag();
@@ -211,7 +211,7 @@ public class BagWriterTest {
             .contains("test-key: test-value", "additional-key: additional-value");
 
         // Assert that tagmanifest-sha512.txt contain the manifest checksums
-        tagFilesContain(Sets.newHashSet(sha512Tagmanifest), Sets.newHashSet(sha1, sha256));
+        tagManifestsContain(Sets.newHashSet(sha512Tagmanifest), Sets.newHashSet(sha1, sha256));
 
         // Finally, pass BagProfile validation and BagIt validation
         validateBag();
@@ -246,7 +246,8 @@ public class BagWriterTest {
         }
     }
 
-    private void tagFilesContain(final Set<Path> tagmanifests, final Set<BagItDigest> contained) throws IOException {
+    private void tagManifestsContain(final Set<Path> tagmanifests, final Set<BagItDigest> contained)
+        throws IOException {
         final String manifestRegex = contained.stream().map(BagItDigest::bagitName).collect(Collectors.joining("|"));
         for (Path tagmanifest : tagmanifests) {
             try (Stream<String> lines = Files.lines(tagmanifest)) {


### PR DESCRIPTION
Resolves #32  

* Updates the BagWriter to allow distinct sets of checksums for payload and tag manifests