### PR TITLE
Improve exception types for better clarity

### DIFF
--- a/src/main/java/org/duraspace/bagit/BagConfig.java
+++ b/src/main/java/org/duraspace/bagit/BagConfig.java
@@ -6,8 +6,8 @@ package org.duraspace.bagit;
 
 import static org.duraspace.bagit.BagProfileConstants.UTF_8;
 
+import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
@@ -26,7 +26,7 @@ import com.esotericsoftware.yamlbeans.YamlReader;
 public class BagConfig {
 
     public enum AccessTypes {
-        RESTRICTED, INSTITUTION, CONSORTIA;
+        RESTRICTED, INSTITUTION, CONSORTIA
     }
 
     public static final String BAG_INFO_KEY = "bag-info.txt";
@@ -63,31 +63,20 @@ public class BagConfig {
 
     public static final String ACCESS_KEY = "Access";
 
-    private Map<String, Map<String, String>> map;
+    private final Map<String, Map<String, String>> map;
 
     /**
      * Default constructor
      *
      * @param bagConfigFile a bagit config yaml file (see src/test/resources/bagit-config.yml)
+     * @exception IOException if there is an error parsing the bagConfigFile
      */
     @SuppressWarnings("unchecked")
-    public BagConfig(final File bagConfigFile) {
-        final String bagConfigFilePath = bagConfigFile.getAbsolutePath();
-
+    public BagConfig(final File bagConfigFile) throws IOException {
         YamlReader reader = null;
-        try {
-            reader = new YamlReader(Files.newBufferedReader(bagConfigFile.toPath(), UTF_8));
+        try (BufferedReader br = Files.newBufferedReader(bagConfigFile.toPath(), UTF_8)) {
+            reader = new YamlReader(br);
             map = (Map<String, Map<String, String>>) reader.read();
-            if (getBagInfo() == null) {
-                throw new RuntimeException("The " + BAG_INFO_KEY + " key is not present in the " + bagConfigFilePath);
-            }
-
-
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException("The specified bag config file does not exist: " + bagConfigFile
-                    .getAbsolutePath());
-        } catch (Exception e) {
-            throw new RuntimeException("The specified bag config file could not be parsed: " + e.getMessage(), e);
         } finally {
             if (reader != null) {
                 try {
@@ -104,7 +93,7 @@ public class BagConfig {
      * @return a map of bag info properties
      */
     public Map<String, String> getBagInfo() {
-        return Collections.unmodifiableMap(this.map.get(BAG_INFO_KEY));
+        return Collections.unmodifiableMap(this.map.getOrDefault(BAG_INFO_KEY, Collections.emptyMap()));
     }
 
     /**
@@ -142,6 +131,6 @@ public class BagConfig {
      * @return a map of filenames to key-value property maps
      */
     public Map<String, String> getFieldsForTagFile(final String tagFile) {
-        return map.get(tagFile);
+        return Collections.unmodifiableMap(map.get(tagFile));
     }
 }

--- a/src/main/java/org/duraspace/bagit/BagConfig.java
+++ b/src/main/java/org/duraspace/bagit/BagConfig.java
@@ -78,7 +78,7 @@ public class BagConfig {
             yaml = new YamlReader(bagConfigReader);
             map = (Map<String, Map<String, String>>) yaml.read();
         } catch (YamlException e) {
-            logger.error("Unable to parse yaml");
+            logger.error("Unable to parse yaml", e);
             throw new IllegalStateException(e);
         } finally {
             if (yaml != null) {

--- a/src/main/java/org/duraspace/bagit/BagConfig.java
+++ b/src/main/java/org/duraspace/bagit/BagConfig.java
@@ -4,17 +4,16 @@
  */
 package org.duraspace.bagit;
 
-import static org.duraspace.bagit.BagProfileConstants.UTF_8;
-
-import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
+import java.io.Reader;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import com.esotericsoftware.yamlbeans.YamlException;
 import com.esotericsoftware.yamlbeans.YamlReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A convenience class for parsing and storing bagit-config.yml information. The bagit-config.yml represents
@@ -24,6 +23,8 @@ import com.esotericsoftware.yamlbeans.YamlReader;
  * @since Dec 14, 2016
  */
 public class BagConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(BagConfig.class);
 
     public enum AccessTypes {
         RESTRICTED, INSTITUTION, CONSORTIA
@@ -68,19 +69,21 @@ public class BagConfig {
     /**
      * Default constructor
      *
-     * @param bagConfigFile a bagit config yaml file (see src/test/resources/bagit-config.yml)
-     * @exception IOException if there is an error parsing the bagConfigFile
+     * @param bagConfigReader a reader for a bagit config yaml file (see src/test/resources/bagit-config.yml)
      */
     @SuppressWarnings("unchecked")
-    public BagConfig(final File bagConfigFile) throws IOException {
-        YamlReader reader = null;
-        try (BufferedReader br = Files.newBufferedReader(bagConfigFile.toPath(), UTF_8)) {
-            reader = new YamlReader(br);
-            map = (Map<String, Map<String, String>>) reader.read();
+    public BagConfig(final Reader bagConfigReader) {
+        YamlReader yaml = null;
+        try {
+            yaml = new YamlReader(bagConfigReader);
+            map = (Map<String, Map<String, String>>) yaml.read();
+        } catch (YamlException e) {
+            logger.error("Unable to parse yaml");
+            throw new IllegalStateException(e);
         } finally {
-            if (reader != null) {
+            if (yaml != null) {
                 try {
-                    reader.close();
+                    yaml.close();
                 } catch (IOException e) {
                 }
             }

--- a/src/main/java/org/duraspace/bagit/BagWriter.java
+++ b/src/main/java/org/duraspace/bagit/BagWriter.java
@@ -99,7 +99,7 @@ public class BagWriter {
      */
     public void registerChecksums(final BagItDigest algorithm, final Map<File, String> filemap) {
         if (!payloadAlgorithms.contains(algorithm)) {
-            throw new RuntimeException("Invalid algorithm: " + algorithm);
+            throw new IllegalArgumentException("Invalid algorithm: " + algorithm);
         }
         payloadRegistry.put(algorithm, filemap);
     }

--- a/src/main/java/org/duraspace/bagit/BagWriter.java
+++ b/src/main/java/org/duraspace/bagit/BagWriter.java
@@ -26,10 +26,9 @@ import java.util.TreeMap;
  */
 public class BagWriter {
 
-    private File bagDir;
-    private File dataDir;
-    private Set<BagItDigest> tagAlgorithms;
-    private Set<BagItDigest> payloadAlgorithms;
+    private final File bagDir;
+    private final Set<BagItDigest> tagAlgorithms;
+    private final Set<BagItDigest> payloadAlgorithms;
 
     private final Map<BagItDigest, Map<File, String>> payloadRegistry;
     private final Map<BagItDigest, Map<File, String>> tagFileRegistry;
@@ -47,7 +46,8 @@ public class BagWriter {
     public static String BAGIT_VERSION = "1.0";
 
     /**
-     * Create a new, empty Bag
+     * Create a new, empty Bag. Create a data directory for the Bag if it does not exist.
+     *
      * @param bagDir The base directory for the Bag (will be created if it doesn't exist)
      * @param algorithms Set of digest algorithms to use for manifests (e.g., "md5", "sha1", or "sha256")
      */
@@ -56,7 +56,7 @@ public class BagWriter {
     }
 
     /**
-     * Create a new, empty Bag
+     * Create a new, empty Bag. Create a data directory for the Bag if it does not exist.
      *
      * @param bagDir The base directory for the Bag (will be created if it doesn't exist)
      * @param payloadAlgorithms Set of digest algorithms to use for payload manifests (e.g., "md5", "sha1", or "sha256")
@@ -65,7 +65,7 @@ public class BagWriter {
     public BagWriter(final File bagDir, final Set<BagItDigest> payloadAlgorithms,
                      final Set<BagItDigest> tagAlgorithms) {
         this.bagDir = bagDir;
-        this.dataDir = new File(bagDir, "data");
+        final File dataDir = new File(bagDir, "data");
         if (!dataDir.exists()) {
             dataDir.mkdirs();
         }

--- a/src/main/java/org/duraspace/bagit/BagWriter.java
+++ b/src/main/java/org/duraspace/bagit/BagWriter.java
@@ -31,15 +31,15 @@ public class BagWriter {
     private Set<BagItDigest> tagAlgorithms;
     private Set<BagItDigest> payloadAlgorithms;
 
-    private Map<BagItDigest, Map<File, String>> payloadRegistry;
-    private Map<BagItDigest, Map<File, String>> tagFileRegistry;
-    private Map<String, Map<String, String>> tagRegistry;
+    private final Map<BagItDigest, Map<File, String>> payloadRegistry;
+    private final Map<BagItDigest, Map<File, String>> tagFileRegistry;
+    private final Map<String, Map<String, String>> tagRegistry;
 
     /**
      * This map provides a way to retrieve all ongoing MessageDigests so that multiple checksums
      * can easily be run and retrieved
      */
-    private Map<BagItDigest, DigestOutputStream> activeStreams;
+    private final Map<BagItDigest, DigestOutputStream> activeStreams;
 
     /**
      * Version of the BagIt specification implemented

--- a/src/main/java/org/duraspace/bagit/GZipBagDeserializer.java
+++ b/src/main/java/org/duraspace/bagit/GZipBagDeserializer.java
@@ -12,7 +12,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.duraspace.bagit.exception.BagProfileException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/duraspace/bagit/GZipBagDeserializer.java
+++ b/src/main/java/org/duraspace/bagit/GZipBagDeserializer.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.duraspace.bagit.exception.BagProfileException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +52,13 @@ public class GZipBagDeserializer implements BagDeserializer {
         }
 
         // Get a deserializer for the deflated content
-        final BagDeserializer deserializer = SerializationSupport.deserializerFor(serializedBag, profile);
+        final BagDeserializer deserializer;
+        try {
+            deserializer = SerializationSupport.deserializerFor(serializedBag, profile);
+        } catch (BagProfileException e) {
+            logger.error("{} is not an accepted format for the given BagProfile!", serializedBag);
+            throw new IOException(e);
+        }
         return deserializer.deserialize(serializedBag);
     }
 }

--- a/src/main/java/org/duraspace/bagit/GZipBagDeserializer.java
+++ b/src/main/java/org/duraspace/bagit/GZipBagDeserializer.java
@@ -42,9 +42,9 @@ public class GZipBagDeserializer implements BagDeserializer {
 
         // Deflate the gzip to get the base file
         logger.info("Deflating gzipped bag: {}", filename);
-        try (InputStream is = Files.newInputStream(root);
-            final InputStream bis = new BufferedInputStream(is);
-            final GzipCompressorInputStream gzipIS = new GzipCompressorInputStream(bis)) {
+        try (final InputStream is = Files.newInputStream(root);
+             final InputStream bis = new BufferedInputStream(is);
+             final GzipCompressorInputStream gzipIS = new GzipCompressorInputStream(bis)) {
 
             Files.copy(gzipIS, serializedBag);
         } catch (FileAlreadyExistsException ex) {
@@ -52,13 +52,7 @@ public class GZipBagDeserializer implements BagDeserializer {
         }
 
         // Get a deserializer for the deflated content
-        final BagDeserializer deserializer;
-        try {
-            deserializer = SerializationSupport.deserializerFor(serializedBag, profile);
-        } catch (BagProfileException e) {
-            logger.error("{} is not an accepted format for the given BagProfile!", serializedBag);
-            throw new IOException(e);
-        }
+        final BagDeserializer deserializer = SerializationSupport.deserializerFor(serializedBag, profile);
         return deserializer.deserialize(serializedBag);
     }
 }

--- a/src/main/java/org/duraspace/bagit/SerializationSupport.java
+++ b/src/main/java/org/duraspace/bagit/SerializationSupport.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.tika.Tika;
+import org.duraspace.bagit.exception.BagProfileException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,10 +101,11 @@ public class SerializationSupport {
      * @param serializedBag the Bag (still serialized) to get a {@link BagDeserializer} for
      * @param profile the {@link BagProfile} to ensure that the content type is allowed
      * @return the {@link BagDeserializer}
-     * @throws UnsupportedOperationException if the content type is not supported
-     * @throws RuntimeException if the {@link BagProfile} does not allow serialization
+     * @throws IOException if the Bag can not be queried for its content type
+     * @throws BagProfileException if the {@link BagProfile} does not allow serialization
      */
-    public static BagDeserializer deserializerFor(final Path serializedBag, final BagProfile profile) {
+    public static BagDeserializer deserializerFor(final Path serializedBag, final BagProfile profile)
+        throws IOException, BagProfileException {
         final Tika tika = new Tika();
         final String contentType;
 
@@ -114,7 +116,7 @@ public class SerializationSupport {
             logger.debug("{}: {}", serializedBag, contentType);
         } catch (IOException e) {
             logger.error("Unable to get content type for {}", serializedBag);
-            throw new RuntimeException(e);
+            throw new IOException(e);
         }
 
         if (profile.getAcceptedSerializations().contains(contentType)) {
@@ -125,12 +127,12 @@ public class SerializationSupport {
             } else if (GZIP_TYPES.contains(contentType)) {
                 return new GZipBagDeserializer(profile);
             } else {
-                throw new UnsupportedOperationException("Unsupported content type " + contentType);
+                throw new BagProfileException("Unsupported content type " + contentType);
             }
         }
 
-        throw new RuntimeException("BagProfile does not allow " + contentType + ". Accepted serializations are:\n" +
-                                   profile.getAcceptedSerializations());
+        throw new BagProfileException("BagProfile does not allow " + contentType + ". Accepted serializations are:\n" +
+                                      profile.getAcceptedSerializations());
     }
 
     /**
@@ -140,9 +142,10 @@ public class SerializationSupport {
      * @param contentType the content type to get a {@link BagSerializer} for
      * @param profile the {@link BagProfile} used for validating the {@code contentType}
      * @return the {@link BagSerializer}
-     * @throws RuntimeException if the {@code contentType} is not supported
+     * @throws BagProfileException if the {@code contentType} is not supported by the {@link BagProfile}
      */
-    public static BagSerializer serializerFor(final String contentType, final BagProfile profile) {
+    public static BagSerializer serializerFor(final String contentType, final BagProfile profile)
+        throws BagProfileException {
         final String type = commonTypeMap.getOrDefault(contentType, contentType);
         if (profile.getAcceptedSerializations().contains(type)) {
             if (ZIP_TYPES.contains(type)) {
@@ -152,11 +155,11 @@ public class SerializationSupport {
             } else if (GZIP_TYPES.contains(type)) {
                 return new TarGzBagSerializer();
             } else {
-                throw new UnsupportedOperationException("Unsupported content type " + contentType);
+                throw new BagProfileException("Unsupported content type " + contentType);
             }
         }
 
-        throw new RuntimeException("BagProfile does not allow " + type + ". Accepted serializations are:\n" +
+        throw new BagProfileException("BagProfile does not allow " + type + ". Accepted serializations are:\n" +
                                    profile.getAcceptedSerializations());
     }
 

--- a/src/main/java/org/duraspace/bagit/SerializationSupport.java
+++ b/src/main/java/org/duraspace/bagit/SerializationSupport.java
@@ -5,6 +5,7 @@
 package org.duraspace.bagit;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -101,13 +102,12 @@ public class SerializationSupport {
      * @param serializedBag the Bag (still serialized) to get a {@link BagDeserializer} for
      * @param profile the {@link BagProfile} to ensure that the content type is allowed
      * @return the {@link BagDeserializer}
-     * @throws IOException if the Bag can not be queried for its content type
      * @throws BagProfileException if the the {@code serializedBag} is not supported by the {@code profile}
+     * @throws UncheckedIOException if the Bag can not be queried for its content type
      * @throws UnsupportedOperationException if the content type of the serialized bag does not have a
      *                                       {@link BagDeserializer}
      */
-    public static BagDeserializer deserializerFor(final Path serializedBag, final BagProfile profile)
-        throws IOException {
+    public static BagDeserializer deserializerFor(final Path serializedBag, final BagProfile profile) {
         final Tika tika = new Tika();
         final String contentType;
 
@@ -118,7 +118,7 @@ public class SerializationSupport {
             logger.debug("{}: {}", serializedBag, contentType);
         } catch (IOException e) {
             logger.error("Unable to get content type for {}", serializedBag);
-            throw new IOException(e);
+            throw new UncheckedIOException(e);
         }
 
         if (profile.getAcceptedSerializations().contains(contentType)) {

--- a/src/main/java/org/duraspace/bagit/SerializationSupport.java
+++ b/src/main/java/org/duraspace/bagit/SerializationSupport.java
@@ -102,10 +102,12 @@ public class SerializationSupport {
      * @param profile the {@link BagProfile} to ensure that the content type is allowed
      * @return the {@link BagDeserializer}
      * @throws IOException if the Bag can not be queried for its content type
-     * @throws BagProfileException if the {@link BagProfile} does not allow serialization
+     * @throws BagProfileException if the the {@code serializedBag} is not supported by the {@code profile}
+     * @throws UnsupportedOperationException if the content type of the serialized bag does not have a
+     *                                       {@link BagDeserializer}
      */
     public static BagDeserializer deserializerFor(final Path serializedBag, final BagProfile profile)
-        throws IOException, BagProfileException {
+        throws IOException {
         final Tika tika = new Tika();
         final String contentType;
 
@@ -127,7 +129,7 @@ public class SerializationSupport {
             } else if (GZIP_TYPES.contains(contentType)) {
                 return new GZipBagDeserializer(profile);
             } else {
-                throw new BagProfileException("Unsupported content type " + contentType);
+                throw new UnsupportedOperationException("Unsupported content type " + contentType);
             }
         }
 
@@ -143,9 +145,9 @@ public class SerializationSupport {
      * @param profile the {@link BagProfile} used for validating the {@code contentType}
      * @return the {@link BagSerializer}
      * @throws BagProfileException if the {@code contentType} is not supported by the {@link BagProfile}
+     * @throws UnsupportedOperationException if the {@code contentType} does not have a built in serializer
      */
-    public static BagSerializer serializerFor(final String contentType, final BagProfile profile)
-        throws BagProfileException {
+    public static BagSerializer serializerFor(final String contentType, final BagProfile profile) {
         final String type = commonTypeMap.getOrDefault(contentType, contentType);
         if (profile.getAcceptedSerializations().contains(type)) {
             if (ZIP_TYPES.contains(type)) {
@@ -155,7 +157,7 @@ public class SerializationSupport {
             } else if (GZIP_TYPES.contains(type)) {
                 return new TarGzBagSerializer();
             } else {
-                throw new BagProfileException("Unsupported content type " + contentType);
+                throw new UnsupportedOperationException("Unsupported content type " + contentType);
             }
         }
 

--- a/src/main/java/org/duraspace/bagit/exception/BagProfileException.java
+++ b/src/main/java/org/duraspace/bagit/exception/BagProfileException.java
@@ -11,7 +11,7 @@ package org.duraspace.bagit.exception;
  *
  * @author mikejritter
  */
-public class BagProfileException extends Exception {
+public class BagProfileException extends RuntimeException {
 
     /**
      * Construct a {@link BagProfileException} with a specified message

--- a/src/main/java/org/duraspace/bagit/exception/BagProfileException.java
+++ b/src/main/java/org/duraspace/bagit/exception/BagProfileException.java
@@ -1,0 +1,24 @@
+/*
+ * The contents of this file are subject to the license and copyright detailed
+ * in the LICENSE and NOTICE files at the root of the source tree.
+ */
+package org.duraspace.bagit.exception;
+
+/**
+ * Signal that an exception has occurred relating to the BagProfile. This can be indicative of a failure to use the
+ * BagProfile properly and trying to perform an invalid operation with the profile (e.g. trying to use a serialization
+ * format which is not supported).
+ *
+ * @author mikejritter
+ */
+public class BagProfileException extends Exception {
+
+    /**
+     * Construct a {@link BagProfileException} with a specified message
+     * @param message the message detailing the error that occurred
+     */
+    public BagProfileException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/test/java/org/duraspace/bagit/BagConfigTest.java
+++ b/src/test/java/org/duraspace/bagit/BagConfigTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 
 import org.junit.Test;
@@ -21,7 +22,7 @@ import org.junit.Test;
 public class BagConfigTest {
 
     @Test
-    public void testFromFile() {
+    public void testFromFile() throws IOException {
         final File testFile = new File("src/test/resources/configs/bagit-config.yml");
         final BagConfig config = new BagConfig(testFile);
 

--- a/src/test/java/org/duraspace/bagit/BagConfigTest.java
+++ b/src/test/java/org/duraspace/bagit/BagConfigTest.java
@@ -9,8 +9,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import org.junit.Test;
@@ -23,8 +25,8 @@ public class BagConfigTest {
 
     @Test
     public void testFromFile() throws IOException {
-        final File testFile = new File("src/test/resources/configs/bagit-config.yml");
-        final BagConfig config = new BagConfig(testFile);
+        final Path testFile = Paths.get("src/test/resources/configs/bagit-config.yml");
+        final BagConfig config = new BagConfig(Files.newBufferedReader(testFile));
 
         final Map<String, String> bagInfo = config.getBagInfo();
         assertNotNull(bagInfo);

--- a/src/test/java/org/duraspace/bagit/BagDeserializerTest.java
+++ b/src/test/java/org/duraspace/bagit/BagDeserializerTest.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
+import org.duraspace.bagit.exception.BagProfileException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +80,7 @@ public class BagDeserializerTest {
             final BagProfile profile = new BagProfile(BagProfile.BuiltIn.BEYOND_THE_REPOSITORY);
             final BagDeserializer deserializer = SerializationSupport.deserializerFor(path, profile);
             deserializer.deserialize(path);
-        } catch (IOException e) {
+        } catch (IOException | BagProfileException e) {
             fail("Unexpected exception:\n" + e.getMessage());
         }
 

--- a/src/test/java/org/duraspace/bagit/BagProfileTest.java
+++ b/src/test/java/org/duraspace/bagit/BagProfileTest.java
@@ -183,7 +183,7 @@ public class BagProfileTest {
 
     @Test
     public void testGoodConfig() throws Exception {
-        final BagConfig config = new BagConfig(resolveResourcePath(bagitConfig).toFile());
+        final BagConfig config = new BagConfig(Files.newBufferedReader(resolveResourcePath(bagitConfig)));
         final Map<String, Map<String, String>> configAsMap =
             config.getTagFiles().stream()
                   .collect(Collectors.toMap(identity(), config::getFieldsForTagFile));
@@ -194,28 +194,28 @@ public class BagProfileTest {
 
     @Test(expected = RuntimeException.class)
     public void testBadAccessValue() throws Exception {
-        final BagConfig config = new BagConfig(resolveResourcePath(bagitConfigBadAccess).toFile());
+        final BagConfig config = new BagConfig(Files.newBufferedReader(resolveResourcePath(bagitConfigBadAccess)));
         final BagProfile profile = new BagProfile(Files.newInputStream(resolveResourcePath(extraTagsPath)));
         profile.validateConfig(config);
     }
 
     @Test(expected = RuntimeException.class)
     public void testMissingAccessValue() throws Exception {
-        final BagConfig config = new BagConfig(resolveResourcePath(bagitConfigMissingAccess).toFile());
+        final BagConfig config = new BagConfig(Files.newBufferedReader(resolveResourcePath(bagitConfigMissingAccess)));
         final BagProfile profile = new BagProfile(Files.newInputStream(resolveResourcePath(extraTagsPath)));
         profile.validateConfig(config);
     }
 
     @Test
     public void testMissingSectionNotNeeded() throws Exception {
-        final BagConfig config = new BagConfig(resolveResourcePath(bagitConfigNoAptrust).toFile());
+        final BagConfig config = new BagConfig(Files.newBufferedReader(resolveResourcePath(bagitConfigNoAptrust)));
         final BagProfile profile = new BagProfile(Files.newInputStream(resolveResourcePath(defaultProfilePath)));
         profile.validateConfig(config);
     }
 
     @Test(expected = RuntimeException.class)
     public void testMissingSectionRequired() throws Exception {
-        final BagConfig config = new BagConfig(resolveResourcePath(bagitConfigNoAptrust).toFile());
+        final BagConfig config = new BagConfig(Files.newBufferedReader(resolveResourcePath(bagitConfigNoAptrust)));
         final BagProfile profile = new BagProfile(Files.newInputStream(resolveResourcePath(extraTagsPath)));
         profile.validateConfig(config);
     }

--- a/src/test/java/org/duraspace/bagit/BagSerializerTest.java
+++ b/src/test/java/org/duraspace/bagit/BagSerializerTest.java
@@ -50,7 +50,7 @@ public class BagSerializerTest {
     }
 
     @Test
-    public void testZipSerializer() throws IOException {
+    public void testZipSerializer() throws Exception {
         final BagSerializer zipper = SerializationSupport.serializerFor("zip", profile);
         final Path writtenBag = zipper.serialize(bag);
 
@@ -69,7 +69,7 @@ public class BagSerializerTest {
     }
 
     @Test
-    public void testTarSerializer() throws IOException {
+    public void testTarSerializer() throws Exception {
         final BagSerializer serializer = SerializationSupport.serializerFor("tar", profile);
         final Path writtenBag = serializer.serialize(bag);
 
@@ -88,7 +88,7 @@ public class BagSerializerTest {
     }
 
     @Test
-    public void testGZipSerializer() throws IOException {
+    public void testGZipSerializer() throws Exception {
         final BagSerializer serializer = SerializationSupport.serializerFor("tgz", profile);
         final Path writtenBag = serializer.serialize(bag);
 

--- a/src/test/java/org/duraspace/bagit/BagWriterTest.java
+++ b/src/test/java/org/duraspace/bagit/BagWriterTest.java
@@ -259,7 +259,7 @@ public class BagWriterTest {
         }
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testAddInvalidAlgorithm() throws IOException {
         // The message digests to use
         final BagItDigest sha1 = BagItDigest.SHA1;

--- a/src/test/java/org/duraspace/bagit/GZipBagDeserializerTest.java
+++ b/src/test/java/org/duraspace/bagit/GZipBagDeserializerTest.java
@@ -1,0 +1,59 @@
+/*
+ * The contents of this file are subject to the license and copyright detailed
+ * in the LICENSE and NOTICE files at the root of the source tree.
+ */
+package org.duraspace.bagit;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.duraspace.bagit.exception.BagProfileException;
+import org.junit.Test;
+
+/**
+ * Test the GZipBagDeserializer in the event the compressed archive which has been extracted from a gzip file is not
+ * supported by a BagProfile.
+ *
+ */
+public class GZipBagDeserializerTest {
+
+    @Test
+    public void testInvalidCompressedBag() throws URISyntaxException, IOException, BagProfileException {
+        // Because the serializers operate strictly on Paths, just compress a file with gz
+        // This allows us to create a "bag" which is not supported by any profile
+        final URL resourcesURI = this.getClass().getClassLoader().getResource("profiles");
+        final Path resources = Paths.get(resourcesURI.toURI());
+        final Path profileJson = resources.resolve("profile.json");
+        final Path invalidGz = resources.resolve("profile.json.gz");
+
+        // compress w/ gzip
+        int n = 0;
+        final byte[] buffer = new byte[2048];
+        try (InputStream bagIn = Files.newInputStream(profileJson);
+            GzipCompressorOutputStream gzOut = new GzipCompressorOutputStream(Files.newOutputStream(invalidGz))) {
+            while (-1 != (n = bagIn.read(buffer))) {
+                gzOut.write(buffer, 0, n);
+            }
+        }
+
+        // for the actually testing, try to deserialize only to run into an exception
+        final BagProfile profile = new BagProfile(BagProfile.BuiltIn.BEYOND_THE_REPOSITORY);
+        final BagDeserializer bagDeserializer = SerializationSupport.deserializerFor(invalidGz, profile);
+
+        try {
+            bagDeserializer.deserialize(invalidGz);
+        } catch (IOException e) {
+            assertThat(e).hasMessageContaining("BagProfile does not allow application/json");
+        }
+    }
+
+}

--- a/src/test/java/org/duraspace/bagit/GZipBagDeserializerTest.java
+++ b/src/test/java/org/duraspace/bagit/GZipBagDeserializerTest.java
@@ -7,9 +7,7 @@ package org.duraspace.bagit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,12 +20,11 @@ import org.junit.Test;
 /**
  * Test the GZipBagDeserializer in the event the compressed archive which has been extracted from a gzip file is not
  * supported by a BagProfile.
- *
  */
 public class GZipBagDeserializerTest {
 
     @Test
-    public void testInvalidCompressedBag() throws URISyntaxException, IOException, BagProfileException {
+    public void testInvalidCompressedBag() throws Exception {
         // Because the serializers operate strictly on Paths, just compress a file with gz
         // This allows us to create a "bag" which is not supported by any profile
         final URL resourcesURI = this.getClass().getClassLoader().getResource("profiles");
@@ -39,7 +36,7 @@ public class GZipBagDeserializerTest {
         int n = 0;
         final byte[] buffer = new byte[2048];
         try (InputStream bagIn = Files.newInputStream(profileJson);
-            GzipCompressorOutputStream gzOut = new GzipCompressorOutputStream(Files.newOutputStream(invalidGz))) {
+             GzipCompressorOutputStream gzOut = new GzipCompressorOutputStream(Files.newOutputStream(invalidGz))) {
             while (-1 != (n = bagIn.read(buffer))) {
                 gzOut.write(buffer, 0, n);
             }
@@ -51,7 +48,7 @@ public class GZipBagDeserializerTest {
 
         try {
             bagDeserializer.deserialize(invalidGz);
-        } catch (IOException e) {
+        } catch (BagProfileException e) {
             assertThat(e).hasMessageContaining("BagProfile does not allow application/json");
         }
     }

--- a/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
+++ b/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
@@ -101,7 +101,7 @@ public class SerializationSupportTest {
         SerializationSupport.deserializerFor(notSupported, profile);
     }
 
-    @Test(expected = BagProfileException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testDeserializationNotSupported() throws Exception {
         // A deserialization format which exists in a profile, but not by bagit-support
         // currently json because we have many json resources available
@@ -121,7 +121,7 @@ public class SerializationSupportTest {
         SerializationSupport.serializerFor(xz, profile);
     }
 
-    @Test(expected = BagProfileException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testSerializerNotSupported() throws Exception {
         // A serialization/compression format which exists in a profile, but not by bagit-support
         // currently 7zip fits this

--- a/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
+++ b/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
+import org.duraspace.bagit.exception.BagProfileException;
 import org.junit.Test;
 
 /**
@@ -88,7 +89,7 @@ public class SerializationSupportTest {
         SerializationSupport.deserializerFor(notFound, profile);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = BagProfileException.class)
     public void testDeserializerNoProfileSupport() throws Exception {
         // Currently the fedora profile only supports application/tar, so send a file which is not a tarball
         // see: profiles/fedora-import-export.json
@@ -100,7 +101,7 @@ public class SerializationSupportTest {
         SerializationSupport.deserializerFor(notSupported, profile);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = BagProfileException.class)
     public void testDeserializationNotSupported() throws Exception {
         // A deserialization format which exists in a profile, but not by bagit-support
         // currently json because we have many json resources available
@@ -112,7 +113,7 @@ public class SerializationSupportTest {
         SerializationSupport.deserializerFor(profileJson, profile);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = BagProfileException.class)
     public void testSerializerNoProfileSupport() throws Exception {
         // A serialization/compression format which does not exist in the profile, currently xz
         final String xz = "application/x-xz";
@@ -120,7 +121,7 @@ public class SerializationSupportTest {
         SerializationSupport.serializerFor(xz, profile);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = BagProfileException.class)
     public void testSerializerNotSupported() throws Exception {
         // A serialization/compression format which exists in a profile, but not by bagit-support
         // currently 7zip fits this

--- a/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
+++ b/src/test/java/org/duraspace/bagit/SerializationSupportTest.java
@@ -14,6 +14,7 @@ import static org.duraspace.bagit.SerializationSupport.APPLICATION_X_GZIP;
 import static org.duraspace.bagit.SerializationSupport.APPLICATION_X_TAR;
 import static org.duraspace.bagit.SerializationSupport.APPLICATION_ZIP;
 
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -82,7 +83,7 @@ public class SerializationSupportTest {
                                                      value -> assertThat(value).isEqualTo(APPLICATION_GZIP));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = UncheckedIOException.class)
     public void testDeserializerForFileNotFound() throws Exception {
         final BagProfile profile = new BagProfile(BagProfile.BuiltIn.FEDORA_IMPORT_EXPORT);
         final Path notFound = Paths.get("file-not-found");


### PR DESCRIPTION
Resolves #4 

* Removes exceptions from BagConfig to allow empty bag-info
* Create BagProfileException for operations which are not valid for a given BagProfile
* Use IllegalArgumentException when given checksums for an algorithm that hasn't been registered
* Use BagProfileException when retrieving serialization classes